### PR TITLE
Extend docker_container healthcheck

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1402,6 +1402,17 @@ class TaskParameters(DockerBaseClass):
                         result[key] = time
                 elif self.healthcheck.get(value):
                     result[key] = self.healthcheck.get(value)
+                    if key == 'test':
+                        if isinstance(result[key], (tuple, list)):
+                            result[key] = [str(e) for e in result[key]]
+                        else:
+                            result[key] = str(result[key])
+                    elif key == 'retries':
+                        try:
+                            result[key] = int(result[key])
+                        except Exception as e:
+                            self.fail('Cannot parse number of retries for healthcheck. '
+                                      'Expected an integer, got "{0}".'.format(result[key]))
 
         return result
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1134,6 +1134,84 @@
     - groups_4 is changed
 
 ####################################################################
+## healthcheck #####################################################
+####################################################################
+
+- name: healthcheck
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 2s
+      interval: 0h0m2s3ms4us
+      retries: 2
+    stop_timeout: 1
+  register: healthcheck_1
+
+- name: healthcheck (idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 2s
+      interval: 0h0m2s3ms4us
+      retries: 2
+    stop_timeout: 1
+  register: healthcheck_2
+
+- name: healthcheck (changed)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - CMD
+      - sleep
+      - 1
+      timeout: 3s
+      interval: 0h1m2s3ms4us
+      retries: 3
+    stop_timeout: 1
+  register: healthcheck_3
+
+- name: healthcheck (disabled)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck: {}
+    stop_timeout: 1
+  register: healthcheck_4
+
+- name: cleanup
+  docker_container:
+    name: "{{ cname }}"
+    state: absent
+    stop_timeout: 1
+
+- assert:
+    that:
+    - healthcheck_1 is changed
+    - healthcheck_2 is not changed
+    - healthcheck_3 is changed
+    - healthcheck_4 is changed
+
+####################################################################
 ## hostname ########################################################
 ####################################################################
 

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1194,9 +1194,23 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
-    healthcheck: {}
+    healthcheck:
+      test:
+      - NONE
     stop_timeout: 1
   register: healthcheck_4
+
+- name: healthcheck (disabled, idempotency)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    healthcheck:
+      test:
+      - NONE
+    stop_timeout: 1
+  register: healthcheck_5
 
 - name: cleanup
   docker_container:
@@ -1210,6 +1224,7 @@
     - healthcheck_2 is not changed
     - healthcheck_3 is changed
     - healthcheck_4 is changed
+    - healthcheck_5 is not changed
 
 ####################################################################
 ## hostname ########################################################


### PR DESCRIPTION
This adds:
 - possibility to disable healthchecks
 - a simple integration test
 - some type conversions to make sure that docker-py / docker daemon won't die with Internal Server Errors

I haven't added a changelog fragment; if you want I can also do that.

Extends ansible/ansible#46772